### PR TITLE
Fix the issue #6

### DIFF
--- a/baseline/train.py
+++ b/baseline/train.py
@@ -195,6 +195,7 @@ class Game(object):
         self.critic.target_model.save_weights("logs/criticmodel.h5", overwrite=True)
         self.actor.target_model.save_weights("logs/actormodel{}.h5".format(self.modelcnt))
         self.critic.target_model.save_weights("logs/criticmodel{}.h5".format(self.modelcnt))
+        self.rpm.save("logs/rpm.pickle")
         print("save")
   
     def pre(self):


### PR DESCRIPTION
I cannot load the rpm after training more than 100 episodes. I found you don't call the 'rpm.save()' in the 'save()' function in 'train.py'. I think probably it's the reason why I got the 'Load fault' in the 'pre()' function.  So I add it. 